### PR TITLE
Fix folder-test API usage

### DIFF
--- a/test/AdditionCalculator.spec.ts
+++ b/test/AdditionCalculator.spec.ts
@@ -6,7 +6,7 @@ import {testFolder} from "@ubccpsc310/folder-test";
 chai.use(chaiAsPromised);
 
 type Input = number[];
-type Output = Promise<number>;
+type Output = number;
 type Error = "TooSimple" | "TooLarge";
 
 describe("AdditionCalculator", function () {
@@ -44,7 +44,7 @@ describe("AdditionCalculator", function () {
 
     testFolder<Input, Output, Error>(
         "Add Dynamic",
-        (input: Input): Output => {
+        (input: Input): Promise<Output> => {
             const additionCalculator = new AdditionCalculator();
             return additionCalculator.add(input);
         },


### PR DESCRIPTION
Just a smol bug!
Affects any students using `assertOnResult`. 

As described in the [`folder-test` API](https://github.com/falkirks/folder-test#api), `folder-test` abstracts over Promises